### PR TITLE
 fixes #7: Contribute all leafs in node, if node is selected by expression

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gwt/VariablesResolverTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gwt/VariablesResolverTest.java
@@ -144,6 +144,44 @@ public class VariablesResolverTest {
   }
 
   @Test
+  public void testJSONPathGetNodeVariable() throws Exception {
+    String resourceName = "gital-mergerequest-comment.json";
+    String postContent = getContent(resourceName);
+
+    String regexpFilter = "";
+    List<GenericVariable> genericVariables =
+        newArrayList( //
+            new GenericVariable("user", "$.user", JSONPath, regexpFilter));
+    Map<String, String[]> parameterMap = new HashMap<>();
+    List<GenericRequestVariable> genericRequestVariables = new ArrayList<>();
+    Map<String, String> variables =
+        new VariablesResolver(parameterMap, postContent, genericVariables, genericRequestVariables)
+            .getVariables();
+
+    assertThat(variables) //
+        .containsEntry("user_name", "Administrator");
+  }
+
+  @Test
+  public void testJSONPathGetPayloadVariable() throws Exception {
+    String resourceName = "gital-mergerequest-comment.json";
+    String postContent = getContent(resourceName);
+
+    String regexpFilter = "";
+    List<GenericVariable> genericVariables =
+        newArrayList( //
+            new GenericVariable("payload", "$", JSONPath, regexpFilter));
+    Map<String, String[]> parameterMap = new HashMap<>();
+    List<GenericRequestVariable> genericRequestVariables = new ArrayList<>();
+    Map<String, String> variables =
+        new VariablesResolver(parameterMap, postContent, genericVariables, genericRequestVariables)
+            .getVariables();
+
+    assertThat(variables) //
+        .containsEntry("payload_user_name", "Administrator");
+  }
+
+  @Test
   public void testXPathGetOneVariable() throws Exception {
     String resourceName = "example.xml";
     String postContent = getContent(resourceName);
@@ -160,6 +198,86 @@ public class VariablesResolverTest {
 
     assertThat(variables) //
         .containsEntry("book", "Harry Potter");
+  }
+
+  @Test
+  public void testXPathGetOneNode() throws Exception {
+    String resourceName = "example.xml";
+    String postContent = getContent(resourceName);
+
+    String regexpFilter = "";
+    List<GenericVariable> genericVariables =
+        newArrayList( //
+            new GenericVariable("book", "/bookstore/book[1]", XPath, regexpFilter));
+    Map<String, String[]> parameterMap = new HashMap<>();
+    List<GenericRequestVariable> genericRequestVariables = new ArrayList<>();
+    Map<String, String> variables =
+        new VariablesResolver(parameterMap, postContent, genericVariables, genericRequestVariables)
+            .getVariables();
+
+    assertThat(variables) //
+        .containsEntry("book_title", "Harry Potter");
+  }
+
+  @Test
+  public void testXPathGetNodes() throws Exception {
+    String resourceName = "example.xml";
+    String postContent = getContent(resourceName);
+
+    String regexpFilter = "";
+    List<GenericVariable> genericVariables =
+        newArrayList( //
+            new GenericVariable("book", "/bookstore/book[*]", XPath, regexpFilter));
+    Map<String, String[]> parameterMap = new HashMap<>();
+    List<GenericRequestVariable> genericRequestVariables = new ArrayList<>();
+    Map<String, String> variables =
+        new VariablesResolver(parameterMap, postContent, genericVariables, genericRequestVariables)
+            .getVariables();
+
+    assertThat(variables) //
+        .containsEntry("book_0_title", "Harry Potter")
+        .containsEntry("book_1_title", "Learning XML");
+  }
+
+  @Test
+  public void testXPathGetPayload() throws Exception {
+    String resourceName = "example.xml";
+    String postContent = getContent(resourceName);
+
+    String regexpFilter = "";
+    List<GenericVariable> genericVariables =
+        newArrayList( //
+            new GenericVariable("payload", "/*", XPath, regexpFilter));
+    Map<String, String[]> parameterMap = new HashMap<>();
+    List<GenericRequestVariable> genericRequestVariables = new ArrayList<>();
+    Map<String, String> variables =
+        new VariablesResolver(parameterMap, postContent, genericVariables, genericRequestVariables)
+            .getVariables();
+
+    assertThat(variables) //
+        .containsEntry("payload_book_0_price", "29.99")
+        .containsEntry("payload_book_0_title", "Harry Potter")
+        .containsEntry("payload_book_1_title", "Learning XML");
+  }
+
+  @Test
+  public void testXPathGetNodeVariable() throws Exception {
+    String resourceName = "example.xml";
+    String postContent = getContent(resourceName);
+
+    String regexpFilter = "";
+    List<GenericVariable> genericVariables =
+        newArrayList( //
+            new GenericVariable("book", "/bookstore/book[1]", XPath, regexpFilter));
+    Map<String, String[]> parameterMap = new HashMap<>();
+    List<GenericRequestVariable> genericRequestVariables = new ArrayList<>();
+    Map<String, String> variables =
+        new VariablesResolver(parameterMap, postContent, genericVariables, genericRequestVariables)
+            .getVariables();
+
+    assertThat(variables) //
+        .containsEntry("book_price", "29.99")
+        .containsEntry("book_title", "Harry Potter");
   }
 
   @Test


### PR DESCRIPTION
PR to expand both JSONPath and XPath variables, if the variable expression selects a node rather than leaf on the payload. So if your payload contains, f.ex.,

```
{
   "object_kind":"note",
   "user":{
      "name":"Administrator",
      "username":"root",
      "avatar_url":"http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80\u0026d=identicon"
   },
...
}
```
you could define a JSONPath variable `user` as `$.user` and the plugin would inject the following variables: `user_name`, `user_username` and `user_avatar_url`. Likewise for XML payloads and XPath variables. Value filters on those variables would get applied then to each expanded variable, individually. Please see `VariableResolverTest` to see how variable expansion naming will work.