### PR TITLE
Add impersonalization to execute Webhook as anonymous user using token

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gwt/GenericWebHookRequestReceiver.java
+++ b/src/main/java/org/jenkinsci/plugins/gwt/GenericWebHookRequestReceiver.java
@@ -47,7 +47,9 @@ public class GenericWebHookRequestReceiver extends CrumbExclusion implements Unp
       LOGGER.log(SEVERE, "", e);
     }
 
-    return doInvoke(headers, parameterMap, postContent);
+    String token =
+        request.getParameter("token") != null ? request.getParameter("token").trim() : null;
+    return doInvoke(headers, parameterMap, postContent, token);
   }
 
   private Map<String, Enumeration<String>> getHeaders(StaplerRequest request) {
@@ -64,8 +66,10 @@ public class GenericWebHookRequestReceiver extends CrumbExclusion implements Unp
   HttpResponse doInvoke(
       Map<String, Enumeration<String>> headers,
       Map<String, String[]> parameterMap,
-      String postContent) {
-    List<GenericTrigger> triggers = JobFinder.findAllJobsWithTrigger();
+      String postContent,
+      String token) {
+
+    List<GenericTrigger> triggers = JobFinder.findAllJobsWithTrigger(token);
     if (triggers.isEmpty()) {
       LOGGER.log(
           INFO,

--- a/src/main/java/org/jenkinsci/plugins/gwt/JobFinder.java
+++ b/src/main/java/org/jenkinsci/plugins/gwt/JobFinder.java
@@ -4,6 +4,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.acegisecurity.context.SecurityContext;
+import org.acegisecurity.context.SecurityContextHolder;
+import org.kohsuke.stapler.StaplerRequest;
+
+import hudson.model.Job;
+import hudson.security.ACL;
 import hudson.triggers.Trigger;
 import hudson.triggers.TriggerDescriptor;
 import jenkins.model.Jenkins;
@@ -12,11 +18,43 @@ import jenkins.model.ParameterizedJobMixIn.ParameterizedJob;
 public final class JobFinder {
   private JobFinder() {}
 
-  public static List<GenericTrigger> findAllJobsWithTrigger() {
+  public static List<GenericTrigger> findAllJobsWithTrigger(String queryStringToken) {
+
     List<GenericTrigger> found = new ArrayList<>();
+    // Impersinate to get all jobs even without read grants
+    SecurityContext orig = ACL.impersonate(ACL.SYSTEM);
     List<ParameterizedJob> candidateProjects =
         Jenkins.getInstance().getAllItems(ParameterizedJob.class);
+    // Return to previous authentication context
+    SecurityContextHolder.setContext(orig);
+
     for (ParameterizedJob candidateJob : candidateProjects) {
+      hudson.model.BuildAuthorizationToken authToken = candidateJob.getAuthToken();
+
+      // do nothing with this job, this does not have a auth token
+      if (authToken != null && authToken.getToken() != null) {
+
+        if (!authToken.getToken().equals(queryStringToken)) {
+          continue;
+        }
+
+      } else {
+
+        try {
+          // Try search again the job with the authentication context
+          // of the user to make sure it only can find it if
+          // authenticated
+          Job<?, ?> j;
+          j = Jenkins.getInstance().getItemByFullName(candidateJob.getName(), Job.class);
+          if (j == null) {
+            continue;
+          }
+        } catch (Exception x) {
+          throw x;
+        } finally {
+          // Just handle any error
+        }
+      }
       GenericTrigger genericTriggerOpt = findGenericTrigger(candidateJob.getTriggers());
       if (genericTriggerOpt != null) {
         found.add(genericTriggerOpt);


### PR DESCRIPTION
Jenkins jobs can only be discovered when the Authentication headers are sent, this work for most of the tools mentioned in the Readme.md (like github, gitlab, etc).

However right now there is a limitation in Jira Cloud that **does not allow** to set the authentication credentials in the webhooks with the format **https://user:apitoken@{jenkins url}/generic-webhook-trigger/invoke?parameter1=value**. 

Jira cloud is simply ignoring the user:token part, Read [this stack overflow](https://stackoverflow.com/questions/38278245/how-to-add-authentication-header-in-jira-webhook)

As a workaround i've used the approach of [build token root plugin](https://github.com/jenkinsci/build-token-root-plugin) to allow anonymous access by providing the "Authentication Token" parameter, so the url finally is accesible like this:

**https://user:apitoken@{jenkins url}/generic-webhook-trigger/invoke?parameter1=value&token=tokenvalue**.
