### PR TITLE
improve header variable name description

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/gwt/GenericHeaderVariable/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/gwt/GenericHeaderVariable/config.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <f:entry title="Request header" description="Name of request header. Resulting variable name has '_' instead of '-' characters.">
+  <f:entry title="Request header" description="Name of request header in lowercase. Resulting variable name has '_' instead of '-' characters.">
     <f:textbox field="key"/>
   </f:entry>
 


### PR DESCRIPTION
Version 1.28 introduced RFC 2616 compatibility making all headers lowercase.

This patch adds a note to make this fact more obvious.

Example situation where this matters: a CI systems that checks for X-GitHub-Event header to make further decisions. Since 1.28 the resulting variable changes from X_GitHub_Event to x_github_event effectively breaking this process.