### PR TITLE
Fixed an error if a resolved variable contains unexpected characters 

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gwt/Renderer.java
+++ b/src/main/java/org/jenkinsci/plugins/gwt/Renderer.java
@@ -50,10 +50,9 @@ public class Renderer {
     final List<String> variables = getVariablesInResolveOrder(resolvedVariables.keySet());
     for (final String variable : variables) {
       regexpFilterText =
-          replaceKey(regexpFilterText, resolvedVariables.get(variable), "\\$" + variable);
+          replaceKey(regexpFilterText, resolvedVariables.get(variable), "$" + variable);
       regexpFilterText =
-          replaceKey(
-              regexpFilterText, resolvedVariables.get(variable), "\\$\\{" + variable + "\\}");
+          replaceKey(regexpFilterText, resolvedVariables.get(variable), "${" + variable + "}");
     }
     return regexpFilterText;
   }
@@ -63,7 +62,7 @@ public class Renderer {
     try {
       regexpFilterText =
           regexpFilterText //
-              .replaceAll(key, resolvedVariable);
+              .replace(key, resolvedVariable);
     } catch (final IllegalArgumentException e) {
       throw new RuntimeException("Tried to replace " + key + " with " + resolvedVariable, e);
     }

--- a/src/test/java/org/jenkinsci/plugins/gwt/RendererTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gwt/RendererTest.java
@@ -81,6 +81,19 @@ public class RendererTest {
   }
 
   @Test
+  public void testThatExceptionNotThrownWithBadResolvedVariable() {
+    resolvedVariables = new TreeMap<>();
+    resolvedVariables.put("key1", "resolved1");
+    resolvedVariables.put("key2", "resolved2($this)");
+
+    final String text = "$key1 $key2";
+    final String actual = renderText(text, resolvedVariables);
+
+    assertThat(actual) //
+        .isEqualTo("resolved1 resolved2($this)");
+  }
+
+  @Test
   public void testThatVariablesCanUseBrackets() {
     resolvedVariables = new TreeMap<>();
     resolvedVariables.put("key1", "resolved1");


### PR DESCRIPTION
STR:
1. Jenkinsfile
```
pipeline {
    agent {
        dockerfile {
            dir 'tests'
            args '-u root:root'
        }
    }
    triggers {
        GenericTrigger(
            genericVariables: [
                [key: 'commit', value: '$.message']
            ],
            causeString: 'Triggered on commit message',
            token: '111',
            printContributedVariables: true,
            printPostContent: true,
            regexpFilterText: '$commit',
            regexpFilterExpression: '\\[run test\\]'
        )
    }
    stages {
        stage('Test') {
            steps {
                sh 'make test'
            }
        }
    }
}
```

2. Webhook payload

```json
{"message": "Fix warning sem_release($this->resource) failed to release key 0x517c: Invalid argument\n -[run test]"}
```

Exception
```
{
    "status": "ok",
    "data": {
        "triggerResults": {
            "multi/master": "Exception occurred, full stack trace in Jenkins server log. Thrown in: org.jenkinsci.plugins.gwt.Renderer:68"
        }
    }
}
```
```
java.lang.IllegalArgumentException: Illegal group reference
	at java.util.regex.Matcher.appendReplacement(Matcher.java:857)
	at java.util.regex.Matcher.replaceAll(Matcher.java:955)
	at java.lang.String.replaceAll(String.java:2223)
	at org.jenkinsci.plugins.gwt.Renderer.replaceKey(Renderer.java:66)
Caused: java.lang.RuntimeException: Tried to replace \$commit with Fix warning sem_release($this->resource) failed to release key 0x517c: Invalid argument
 -[run test]
	at org.jenkinsci.plugins.gwt.Renderer.replaceKey(Renderer.java:68)
	at org.jenkinsci.plugins.gwt.Renderer.renderText(Renderer.java:53)
	at org.jenkinsci.plugins.gwt.GenericTrigger.trigger(GenericTrigger.java:119)
	at org.jenkinsci.plugins.gwt.GenericWebHookRequestReceiver.doInvoke(GenericWebHookRequestReceiver.java:107)
	at org.jenkinsci.plugins.gwt.GenericWebHookRequestReceiver.doInvoke(GenericWebHookRequestReceiver.java:56)
	at java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:627)
	at org.kohsuke.stapler.Function$MethodFunction.invoke(Function.java:343)
	at org.kohsuke.stapler.Function.bindAndInvoke(Function.java:184)
	at org.kohsuke.stapler.Function.bindAndInvokeAndServeResponse(Function.java:117)
	at org.kohsuke.stapler.MetaClass$1.doDispatch(MetaClass.java:129)
	at org.kohsuke.stapler.NameBasedDispatcher.dispatch(NameBasedDispatcher.java:58)
	at org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:734)
	at org.kohsuke.stapler.Stapler.invoke(Stapler.java:864)
	at org.kohsuke.stapler.MetaClass$10.dispatch(MetaClass.java:374)
	at org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:734)
	at org.kohsuke.stapler.Stapler.invoke(Stapler.java:864)
	at org.kohsuke.stapler.Stapler.invoke(Stapler.java:668)
	at org.kohsuke.stapler.Stapler.service(Stapler.java:238)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
	at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:860)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1650)
	at hudson.util.PluginServletFilter$1.doFilter(PluginServletFilter.java:154)
	at hudson.util.PluginServletFilter.doFilter(PluginServletFilter.java:157)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1637)
	at org.jenkinsci.plugins.gwt.GenericWebHookRequestReceiver.process(GenericWebHookRequestReceiver.java:145)
	at hudson.security.csrf.CrumbFilter.doFilter(CrumbFilter.java:73)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1637)
	at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:84)
	at hudson.security.UnwrapSecurityExceptionFilter.doFilter(UnwrapSecurityExceptionFilter.java:51)
	at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:87)
	at jenkins.security.ExceptionTranslationFilter.doFilter(ExceptionTranslationFilter.java:117)
	at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:87)
	at org.acegisecurity.providers.anonymous.AnonymousProcessingFilter.doFilter(AnonymousProcessingFilter.java:125)
	at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:87)
	at org.acegisecurity.ui.rememberme.RememberMeProcessingFilter.doFilter(RememberMeProcessingFilter.java:135)
	at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:87)
	at org.acegisecurity.ui.AbstractProcessingFilter.doFilter(AbstractProcessingFilter.java:271)
	at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:87)
	at jenkins.security.BasicHeaderProcessor.doFilter(BasicHeaderProcessor.java:93)
	at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:87)
	at org.acegisecurity.context.HttpSessionContextIntegrationFilter.doFilter(HttpSessionContextIntegrationFilter.java:249)
	at hudson.security.HttpSessionContextIntegrationFilter2.doFilter(HttpSessionContextIntegrationFilter2.java:67)
	at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:87)
	at hudson.security.ChainedServletFilter.doFilter(ChainedServletFilter.java:90)
	at hudson.security.HudsonFilter.doFilter(HudsonFilter.java:171)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1637)
	at org.kohsuke.stapler.compression.CompressionFilter.doFilter(CompressionFilter.java:49)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1637)
	at hudson.util.CharacterEncodingFilter.doFilter(CharacterEncodingFilter.java:82)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1637)
	at org.kohsuke.stapler.DiagnosticThreadNameFilter.doFilter(DiagnosticThreadNameFilter.java:30)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1637)
	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:533)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:143)
	at org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:524)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:190)
	at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:1595)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:188)
	at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1253)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:168)
	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:473)
	at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1564)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:166)
	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1155)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)
	at org.eclipse.jetty.server.Server.handle(Server.java:530)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:347)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:256)
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:279)
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:102)
	at org.eclipse.jetty.io.ChannelEndPoint$2.run(ChannelEndPoint.java:124)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:247)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.produce(EatWhatYouKill.java:140)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:131)
	at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:382)
	at winstone.BoundedExecutorService$1.run(BoundedExecutorService.java:77)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```