### PR TITLE
Use the job's configured quiet period

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gwt/GenericTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/gwt/GenericTrigger.java
@@ -139,7 +139,7 @@ public class GenericTrigger extends Trigger<Job<?, ?>> {
           createParameterAction(parametersDefinitionProperty, resolvedVariables);
       item =
           retrieveScheduleJob(job) //
-              .scheduleBuild2(job, 0, new CauseAction(genericCause), parameters);
+              .scheduleBuild2(job, -1, new CauseAction(genericCause), parameters);
     }
     return new GenericTriggerResults(
         item, resolvedVariables, renderedRegexpFilterText, regexpFilterExpression);


### PR DESCRIPTION
-1 is the magic number for scheduleBuild2 to use the configured quiet period.  0 will make the build happen immediately, regardless of the job configuration.