### PR TITLE
Demonstrating jenkinsci/plugin-pom#236

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,20 @@ Changelog of Generic Webhook Plugin.
 [23bbefcc5b0dd39](https://github.com/jenkinsci/generic-webhook-trigger-plugin/commit/23bbefcc5b0dd39) Tomas Bjerre *2019-09-02 15:36:33*
 
 
+### GitHub [#136](https://github.com/jenkinsci/generic-webhook-trigger-plugin/issues/136) Ability to add more optional filters to run the job based on OR operations of two AND operations.    *question*  
+
+**Testing combination of variables #136**
+
+
+[e02cb6ccfd88325](https://github.com/jenkinsci/generic-webhook-trigger-plugin/commit/e02cb6ccfd88325) Tomas Bjerre *2019-09-29 09:18:16*
+
+
 ### No issue
+
+**doc**
+
+
+[722aaf227e3dd56](https://github.com/jenkinsci/generic-webhook-trigger-plugin/commit/722aaf227e3dd56) Tomas Bjerre *2019-10-03 13:28:49*
 
 **Create FUNDING.yml**
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,16 +3,17 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>3.2</version>
+		<version>3.51-SNAPSHOT</version>
 	</parent>
 
 	<properties>
 		<java.level>7</java.level>
 		<jenkins.version>2.7.4</jenkins.version>
-		<findbugs.failOnError>false</findbugs.failOnError>
+                <violations.maxViolations>2</violations.maxViolations>
+                <spotbugs.failOnError>false</spotbugs.failOnError>
+                <findbugs.failOnError>false</findbugs.failOnError>
 		<maven.javadoc.skip>true</maven.javadoc.skip>
 		<fmt>2.9</fmt>
-		<violations.version>1.20</violations.version>
 		<changelog>1.60</changelog>
 	</properties>
 
@@ -159,35 +160,6 @@ Changelog of Generic Webhook Plugin.
 					</execution>
 				</executions>
 			</plugin>
-			<plugin>
-				<groupId>se.bjurr.violations</groupId>
-				<artifactId>violations-maven-plugin</artifactId>
-				<version>${violations.version}</version>
-				<executions>
-					<execution>
-						<phase>verify</phase>
-						<goals>
-							<goal>violations</goal>
-						</goals>
-						<configuration>
-							<minSeverity>INFO</minSeverity>
-							<detailLevel>VERBOSE</detailLevel>
-							<maxViolations>99999999</maxViolations>
-							<printViolations>true</printViolations>
-
-							<violations>
-								<violation>
-									<parser>FINDBUGS</parser>
-									<reporter>Findbugs</reporter>
-									<folder>.</folder>
-									<pattern>.*/findbugsXml\.xml$</pattern>
-								</violation>
-							</violations>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-
 		</plugins>
 		<resources>
 			<resource>

--- a/src/main/java/org/jenkinsci/plugins/gwt/GenericTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/gwt/GenericTrigger.java
@@ -42,6 +42,7 @@ public class GenericTrigger extends Trigger<Job<?, ?>> {
 
     @Override
     public boolean isApplicable(final Item item) {
+      if (item == null) item.toString();
       return Job.class.isAssignableFrom(item.getClass());
     }
 


### PR DESCRIPTION
```bash

[2019-10-12T06:07:08.315Z] [ERROR] Failed to execute goal se.bjurr.violations:violations-maven-plugin:1.28:violations (default) on project generic-webhook-trigger: Too many violations found, max is 2 but found 5
[2019-10-12T06:07:08.315Z] [ERROR] org/jenkinsci/plugins/gwt/GenericTrigger.java
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      |                              |
[2019-10-12T06:07:08.315Z] [ERROR] | Reporter | Rule                                   | Severity | Line | Message                      |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      |                              |
[2019-10-12T06:07:08.315Z] [ERROR] +----------+----------------------------------------+----------+------+------------------------------+
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      |                              |
[2019-10-12T06:07:08.315Z] [ERROR] | Spotbugs | RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT | INFO     | 145  | Return   value   of   method |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | without   side   effect   is |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | ignored <p>This code calls a |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | method   and   ignores   the |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | return  value.  However  our |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | analysis  shows   that   the |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | method    (including     its |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | implementations           in |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | subclasses if any) does  not |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | produce  any  effect   other |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | than return value. Thus this |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | call can  be  removed.  </p> |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | <p>We are trying  to  reduce |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | the false positives as  much |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | as  possible,  but  in  some |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | cases this warning might  be |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | wrong. Common false-positive |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | cases include:</p> <p>-  The |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | method  is  designed  to  be |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | overridden  and  produce   a |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | side   effect    in    other |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | projects which  are  out  of |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | the     scope     of     the |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | analysis.</p>    <p>-    The |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | method is called to  trigger |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | the class loading which  may |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | have a side effect.</p> <p>- |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | The method is called just to |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | get   some    exception.</p> |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | <p>If  you  feel  that   our |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | assumption is incorrect, you |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | can use a  @CheckReturnValue |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | annotation    to    instruct |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | FindBugs that  ignoring  the |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | return value of this  method |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | is acceptable. </p>          |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      |                              |
[2019-10-12T06:07:08.315Z] [ERROR] +----------+----------------------------------------+----------+------+------------------------------+
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      |                              |
[2019-10-12T06:07:08.315Z] [ERROR] | Spotbugs | NP_NULL_ON_SOME_PATH                   | ERROR    | 140  | Possible    null     pointer |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | dereference <p> There  is  a |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | branch  of  statement  that, |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | <em>if        executed,</em> |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | guarantees that a null value |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | will be dereferenced,  which |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | would       generate       a |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | <code>NullPointerException</ |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | code>  when  the   code   is |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | executed.  Of  course,   the |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | problem might  be  that  the |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | branch   or   statement   is |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | infeasible and that the null |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | pointer exception can't ever |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | be executed;  deciding  that |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | is  beyond  the  ability  of |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | FindBugs. </p>               |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      |                              |
[2019-10-12T06:07:08.315Z] [ERROR] +----------+----------------------------------------+----------+------+------------------------------+
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      |                              |
[2019-10-12T06:07:08.315Z] [ERROR] | Spotbugs | NP_LOAD_OF_KNOWN_NULL_VALUE            | INFO     | 45   | Load of known null value <p> |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | The variable  referenced  at |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | this point is  known  to  be |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | null due to an earlier check |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | against null. Although  this |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | is  valid,  it  might  be  a |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | mistake     (perhaps     you |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | intended  to  refer   to   a |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | different    variable,    or |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | perhaps the earlier check to |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | see if the variable is  null |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | should have been a check  to |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | see  if  it  was  non-null). |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | </p>                         |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      |                              |
[2019-10-12T06:07:08.315Z] [ERROR] +----------+----------------------------------------+----------+------+------------------------------+
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      |                              |
[2019-10-12T06:07:08.315Z] [ERROR] | Spotbugs | NP_ALWAYS_NULL                         | ERROR    | 45   | Null pointer dereference <p> |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | A    null     pointer     is |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | dereferenced     here.&nbsp; |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | This   will   lead   to    a |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | <code>NullPointerException</ |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | code>  when  the   code   is |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | executed.</p>                |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      |                              |
[2019-10-12T06:07:08.315Z] [ERROR] +----------+----------------------------------------+----------+------+------------------------------+
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      |                              |
[2019-10-12T06:07:08.315Z] [ERROR] | Spotbugs | RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT | INFO     | 45   | Return   value   of   method |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | without   side   effect   is |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | ignored <p>This code calls a |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | method   and   ignores   the |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | return  value.  However  our |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | analysis  shows   that   the |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | method    (including     its |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | implementations           in |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | subclasses if any) does  not |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | produce  any  effect   other |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | than return value. Thus this |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | call can  be  removed.  </p> |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | <p>We are trying  to  reduce |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | the false positives as  much |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | as  possible,  but  in  some |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | cases this warning might  be |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | wrong. Common false-positive |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | cases include:</p> <p>-  The |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | method  is  designed  to  be |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | overridden  and  produce   a |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | side   effect    in    other |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | projects which  are  out  of |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | the     scope     of     the |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | analysis.</p>    <p>-    The |
[2019-10-12T06:07:08.315Z] [ERROR] |          |                                        |          |      | method is called to  trigger |
[2019-10-12T06:07:08.316Z] [ERROR] |          |                                        |          |      | the class loading which  may |
[2019-10-12T06:07:08.316Z] [ERROR] |          |                                        |          |      | have a side effect.</p> <p>- |
[2019-10-12T06:07:08.316Z] [ERROR] |          |                                        |          |      | The method is called just to |
[2019-10-12T06:07:08.316Z] [ERROR] |          |                                        |          |      | get   some    exception.</p> |
[2019-10-12T06:07:08.316Z] [ERROR] |          |                                        |          |      | <p>If  you  feel  that   our |
[2019-10-12T06:07:08.316Z] [ERROR] |          |                                        |          |      | assumption is incorrect, you |
[2019-10-12T06:07:08.316Z] [ERROR] |          |                                        |          |      | can use a  @CheckReturnValue |
[2019-10-12T06:07:08.316Z] [ERROR] |          |                                        |          |      | annotation    to    instruct |
[2019-10-12T06:07:08.316Z] [ERROR] |          |                                        |          |      | FindBugs that  ignoring  the |
[2019-10-12T06:07:08.316Z] [ERROR] |          |                                        |          |      | return value of this  method |
[2019-10-12T06:07:08.316Z] [ERROR] |          |                                        |          |      | is acceptable. </p>          |
[2019-10-12T06:07:08.316Z] [ERROR] |          |                                        |          |      |                              |
[2019-10-12T06:07:08.316Z] [ERROR] +----------+----------------------------------------+----------+------+------------------------------+
[2019-10-12T06:07:08.316Z] [ERROR] Summary of org/jenkinsci/plugins/gwt/GenericTrigger.java
[2019-10-12T06:07:08.316Z] [ERROR] |          |      |      |       |       |
[2019-10-12T06:07:08.316Z] [ERROR] | Reporter | INFO | WARN | ERROR | Total |
[2019-10-12T06:07:08.316Z] [ERROR] |          |      |      |       |       |
[2019-10-12T06:07:08.316Z] [ERROR] +----------+------+------+-------+-------+
[2019-10-12T06:07:08.316Z] [ERROR] |          |      |      |       |       |
[2019-10-12T06:07:08.316Z] [ERROR] | Spotbugs | 3    | 0    | 2     | 5     |
[2019-10-12T06:07:08.316Z] [ERROR] |          |      |      |       |       |
[2019-10-12T06:07:08.316Z] [ERROR] +----------+------+------+-------+-------+
[2019-10-12T06:07:08.316Z] [ERROR] |          |      |      |       |       |
[2019-10-12T06:07:08.316Z] [ERROR] |          | 3    | 0    | 2     | 5     |
[2019-10-12T06:07:08.316Z] [ERROR] |          |      |      |       |       |
[2019-10-12T06:07:08.316Z] [ERROR] +----------+------+------+-------+-------+
[2019-10-12T06:07:08.316Z] [ERROR] 
[2019-10-12T06:07:08.316Z] [ERROR] 
[2019-10-12T06:07:08.316Z] [ERROR] Summary
[2019-10-12T06:07:08.316Z] [ERROR] |          |      |      |       |       |
[2019-10-12T06:07:08.316Z] [ERROR] | Reporter | INFO | WARN | ERROR | Total |
[2019-10-12T06:07:08.316Z] [ERROR] |          |      |      |       |       |
[2019-10-12T06:07:08.316Z] [ERROR] +----------+------+------+-------+-------+
[2019-10-12T06:07:08.316Z] [ERROR] |          |      |      |       |       |
[2019-10-12T06:07:08.316Z] [ERROR] | Spotbugs | 3    | 0    | 2     | 5     |
[2019-10-12T06:07:08.316Z] [ERROR] |          |      |      |       |       |
[2019-10-12T06:07:08.316Z] [ERROR] +----------+------+------+-------+-------+
[2019-10-12T06:07:08.316Z] [ERROR] |          |      |      |       |       |
[2019-10-12T06:07:08.316Z] [ERROR] |          | 3    | 0    | 2     | 5     |
[2019-10-12T06:07:08.316Z] [ERROR] |          |      |      |       |       |
[2019-10-12T06:07:08.316Z] [ERROR] +----------+------+------+-------+-------+
```