### PR TITLE
Support CIDR Notation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,42 +241,6 @@ Changelog of Generic Webhook Plugin.
 			</exclusions>
 		</dependency>
 		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-			<version>28.1-jre</version>
-			<exclusions>
-					<!--https://github.com/google/guava/issues/2824-->
-					<exclusion>
-							<groupId>com.google.guava</groupId>
-							<artifactId>failureaccess</artifactId>
-					</exclusion>
-					<exclusion>
-							<groupId>com.google.guava</groupId>
-							<artifactId>listenablefuture</artifactId>
-					</exclusion>
-					<exclusion>
-							<groupId>com.google.code.findbugs</groupId>
-							<artifactId>jsr305</artifactId>
-					</exclusion>
-					<exclusion>
-							<groupId>org.checkerframework</groupId>
-							<artifactId>checker-qual</artifactId>
-					</exclusion>
-					<exclusion>
-							<groupId>com.google.errorprone</groupId>
-							<artifactId>error_prone_annotations</artifactId>
-					</exclusion>
-					<exclusion>
-							<groupId>com.google.j2objc</groupId>
-							<artifactId>j2objc-annotations</artifactId>
-					</exclusion>
-					<exclusion>
-							<groupId>org.codehaus.mojo</groupId>
-							<artifactId>animal-sniffer-annotations</artifactId>
-					</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
 			<groupId>com.github.jgonian</groupId>
 			<artifactId>commons-ip-math</artifactId>
 			<version>1.32</version>

--- a/pom.xml
+++ b/pom.xml
@@ -7,12 +7,12 @@
 	</parent>
 
 	<properties>
-		<java.level>7</java.level>
+		<java.level>8</java.level>
 		<jenkins.version>2.7.4</jenkins.version>
 		<findbugs.failOnError>false</findbugs.failOnError>
 		<maven.javadoc.skip>true</maven.javadoc.skip>
 		<fmt>2.9</fmt>
-		<violations.version>1.29</violations.version>
+		<violations.version>1.30</violations.version>
 		<changelog>1.60</changelog>
 	</properties>
 
@@ -239,6 +239,47 @@ Changelog of Generic Webhook Plugin.
 					<artifactId>structs</artifactId>
 				</exclusion>
 			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>28.1-jre</version>
+			<exclusions>
+					<!--https://github.com/google/guava/issues/2824-->
+					<exclusion>
+							<groupId>com.google.guava</groupId>
+							<artifactId>failureaccess</artifactId>
+					</exclusion>
+					<exclusion>
+							<groupId>com.google.guava</groupId>
+							<artifactId>listenablefuture</artifactId>
+					</exclusion>
+					<exclusion>
+							<groupId>com.google.code.findbugs</groupId>
+							<artifactId>jsr305</artifactId>
+					</exclusion>
+					<exclusion>
+							<groupId>org.checkerframework</groupId>
+							<artifactId>checker-qual</artifactId>
+					</exclusion>
+					<exclusion>
+							<groupId>com.google.errorprone</groupId>
+							<artifactId>error_prone_annotations</artifactId>
+					</exclusion>
+					<exclusion>
+							<groupId>com.google.j2objc</groupId>
+							<artifactId>j2objc-annotations</artifactId>
+					</exclusion>
+					<exclusion>
+							<groupId>org.codehaus.mojo</groupId>
+							<artifactId>animal-sniffer-annotations</artifactId>
+					</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>com.github.jgonian</groupId>
+			<artifactId>commons-ip-math</artifactId>
+			<version>1.32</version>
 		</dependency>
 
 		<!-- test // -->

--- a/src/main/java/org/jenkinsci/plugins/gwt/global/WhitelistItem.java
+++ b/src/main/java/org/jenkinsci/plugins/gwt/global/WhitelistItem.java
@@ -109,8 +109,9 @@ public class WhitelistItem extends AbstractDescribableImpl<WhitelistItem> implem
 
   /**
    * Returns true if the provided value is a valid ipv4/ipv6 string.
+   * 
    * @param ipValue
-   * @return
+   * @return Boolean
    */
   private Boolean validateIpValue(String ipValue) {
     Boolean isValid = false;
@@ -158,6 +159,7 @@ public class WhitelistItem extends AbstractDescribableImpl<WhitelistItem> implem
 
   /**
    * See: https://wiki.jenkins.io/display/JENKINS/Form+Validation
+   *
    * @param value
    * @return FormValidation
    * @throws Exception

--- a/src/main/java/org/jenkinsci/plugins/gwt/global/WhitelistItem.java
+++ b/src/main/java/org/jenkinsci/plugins/gwt/global/WhitelistItem.java
@@ -107,6 +107,11 @@ public class WhitelistItem extends AbstractDescribableImpl<WhitelistItem> implem
     }
   }
 
+  /**
+   * Returns true if the provided value is a valid ipv4/ipv6 string.
+   * @param ipValue
+   * @return
+   */
   private Boolean validateIpValue(String ipValue) {
     Boolean isValid = false;
 
@@ -151,6 +156,12 @@ public class WhitelistItem extends AbstractDescribableImpl<WhitelistItem> implem
     return isValid;
   }
 
+  /**
+   * See: https://wiki.jenkins.io/display/JENKINS/Form+Validation
+   * @param value
+   * @return FormValidation
+   * @throws Exception
+   */
   public FormValidation doCheckHost(@QueryParameter String value) throws Exception {
     try {
       if (validateIpValue(value)) {

--- a/src/main/java/org/jenkinsci/plugins/gwt/whitelist/WhitelistVerifier.java
+++ b/src/main/java/org/jenkinsci/plugins/gwt/whitelist/WhitelistVerifier.java
@@ -104,10 +104,8 @@ public class WhitelistVerifier {
   /** Returns true if whitelistHost contains remoteHost; supports ip/cidr. */
   static Boolean whitelistContains(final String remoteHost, final String whitelistHost)
       throws WhitelistException {
-    Boolean isMatched = false;
-
     if (whitelistHost.equalsIgnoreCase(remoteHost)) {
-      isMatched = true;
+      return true;
     }
 
     Boolean isCIDR = false;
@@ -126,11 +124,17 @@ public class WhitelistVerifier {
       }
     }
 
-    if (isCIDR || isRange) {
-      whitelistHostIP = hostParts[0];
-      isMatched = verifyCIDR(remoteHost, whitelistHost, whitelistHostIP);
-    } else {
-      isMatched = verifyIP(remoteHost, whitelistHost);
+    Boolean isMatched = false;
+
+    try {
+      if (isCIDR || isRange) {
+        whitelistHostIP = hostParts[0];
+        isMatched = verifyCIDR(remoteHost, whitelistHost, whitelistHostIP);
+      } else {
+        isMatched = verifyIP(remoteHost, whitelistHost);
+      }
+    } catch (Exception e) {
+      isMatched = false;
     }
 
     return isMatched;

--- a/src/main/java/org/jenkinsci/plugins/gwt/whitelist/WhitelistVerifier.java
+++ b/src/main/java/org/jenkinsci/plugins/gwt/whitelist/WhitelistVerifier.java
@@ -8,14 +8,12 @@ import com.github.jgonian.ipmath.Ipv6;
 import com.github.jgonian.ipmath.Ipv6Range;
 import com.google.common.base.Optional;
 import com.google.common.net.InetAddresses;
-import hudson.util.FormValidation;
 import java.util.List;
 import java.util.Map;
 import org.jenkinsci.plugins.gwt.global.CredentialsHelper;
 import org.jenkinsci.plugins.gwt.global.Whitelist;
 import org.jenkinsci.plugins.gwt.global.WhitelistItem;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
-import org.kohsuke.stapler.QueryParameter;
 
 public class WhitelistVerifier {
 
@@ -165,57 +163,5 @@ public class WhitelistVerifier {
     }
     throw new WhitelistException(
         "Sending host \"" + remoteHost + "\" was not matched by whitelist.");
-  }
-
-  private Boolean validateIpValue(String ipValue) {
-    Boolean isValid = false;
-
-    Boolean isCIDR = false;
-    Boolean isRange = false;
-
-    String[] hostParts = ipValue.split("/");
-
-    if (hostParts.length == 2) {
-      isCIDR = true;
-    } else {
-      hostParts = ipValue.split("-");
-      if (hostParts.length == 2) {
-        isRange = true;
-      }
-    }
-
-    if (isCIDR || isRange) {
-      int leftValueLength = InetAddresses.forString(hostParts[0]).getAddress().length;
-      if (leftValueLength == 4) {
-        if (Ipv4Range.parse(ipValue) != null) {
-          isValid = true;
-        }
-      } else if (leftValueLength == 16) {
-        if (Ipv6Range.parse(ipValue) != null) {
-          isValid = true;
-        }
-      }
-    } else {
-      int ipValueLength = InetAddresses.forString(hostParts[0]).getAddress().length;
-      if (ipValueLength == 4) {
-        if (Ipv4.parse(ipValue) != null) {
-          isValid = true;
-        }
-      } else if (ipValueLength == 16) {
-        if (Ipv6.parse(ipValue) != null) {
-          isValid = true;
-        }
-      }
-    }
-
-    return isValid;
-  }
-
-  public FormValidation checkIP(@QueryParameter String value) {
-    if (validateIpValue(value)) {
-      return FormValidation.ok();
-    } else {
-      return FormValidation.error("IP Address must be in IPV4 or IPV6 CIDR or IP range notation.");
-    }
   }
 }

--- a/src/main/java/org/jenkinsci/plugins/gwt/whitelist/WhitelistVerifier.java
+++ b/src/main/java/org/jenkinsci/plugins/gwt/whitelist/WhitelistVerifier.java
@@ -48,7 +48,15 @@ public class WhitelistVerifier {
     throw new WhitelistException("Did not find a matching whitelisted host:\n" + messagesString);
   }
 
-  /** Returns true if whitelistHost CIDR block contains remoteHost; supports ipv4/ipv6. */
+  /**
+   * Returns true if the provided whitelistHost CIDR block contains the
+   * remoteHost; supports ipv4/ipv6.
+   * @param remoteHost
+   * @param whitelistHostCIDR
+   * @param whitelistHostIP
+   * @return
+   * @throws WhitelistException
+   */
   static boolean verifyCIDR(
       final String remoteHost, final String whitelistHostCIDR, final String whitelistHostIP)
       throws WhitelistException {
@@ -70,19 +78,42 @@ public class WhitelistVerifier {
     return false;
   }
 
+  /**
+   * Returns true if the provided ipv4 remoteHost value is equal to the ipv4
+   * whitelistHost value.
+   * @param remoteHost
+   * @param whitelistHost
+   * @return
+   * @throws WhitelistException
+   */
   static boolean verifyIpv4(final String remoteHost, final String whitelistHost)
       throws WhitelistException {
     Ipv4 whitelistIP = Ipv4.parse(whitelistHost);
     return whitelistIP.equals(Ipv4.parse(remoteHost));
   }
 
+  
+  /**
+   * Returns true if the provided ipv6 remoteHost value is equal to the ipv6
+   * whitelistHost value.
+   * @param remoteHost
+   * @param whitelistHost
+   * @return
+   * @throws WhitelistException
+   */
   static boolean verifyIpv6(final String remoteHost, final String whitelistHost)
       throws WhitelistException {
     Ipv6 whitelistIP = Ipv6.parse(whitelistHost);
     return whitelistIP.equals(Ipv6.parse(remoteHost));
   }
 
-  /** Returns true if whitelistHost is equal to remoteHost; supports ipv4/ipv6. */
+  /**
+   * Returns true if whitelistHost is equal to remoteHost; supports ipv4/ipv6.
+   * @param remoteHost
+   * @param whitelistHost
+   * @return
+   * @throws WhitelistException
+   */
   static boolean verifyIP(final String remoteHost, final String whitelistHost)
       throws WhitelistException {
 
@@ -101,7 +132,13 @@ public class WhitelistVerifier {
     return false;
   }
 
-  /** Returns true if whitelistHost contains remoteHost; supports ip/cidr. */
+  /**
+   * Returns true if whitelistHost contains remoteHost; supports ip/cidr.
+   * @param remoteHost
+   * @param whitelistHost
+   * @return
+   * @throws WhitelistException
+   */
   static Boolean whitelistContains(final String remoteHost, final String whitelistHost)
       throws WhitelistException {
     if (whitelistHost.equalsIgnoreCase(remoteHost)) {

--- a/src/main/java/org/jenkinsci/plugins/gwt/whitelist/WhitelistVerifier.java
+++ b/src/main/java/org/jenkinsci/plugins/gwt/whitelist/WhitelistVerifier.java
@@ -2,13 +2,20 @@ package org.jenkinsci.plugins.gwt.whitelist;
 
 import static org.jenkinsci.plugins.gwt.whitelist.HMACVerifier.hmacVerify;
 
+import com.github.jgonian.ipmath.Ipv4;
+import com.github.jgonian.ipmath.Ipv4Range;
+import com.github.jgonian.ipmath.Ipv6;
+import com.github.jgonian.ipmath.Ipv6Range;
 import com.google.common.base.Optional;
+import com.google.common.net.InetAddresses;
+import hudson.util.FormValidation;
 import java.util.List;
 import java.util.Map;
 import org.jenkinsci.plugins.gwt.global.CredentialsHelper;
 import org.jenkinsci.plugins.gwt.global.Whitelist;
 import org.jenkinsci.plugins.gwt.global.WhitelistItem;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+import org.kohsuke.stapler.QueryParameter;
 
 public class WhitelistVerifier {
 
@@ -43,13 +50,104 @@ public class WhitelistVerifier {
     throw new WhitelistException("Did not find a matching whitelisted host:\n" + messagesString);
   }
 
+  /** Returns true if whitelistHost CIDR block contains remoteHost; supports ipv4/ipv6. */
+  static boolean verifyCIDR(
+      final String remoteHost, final String whitelistHostCIDR, final String whitelistHostIP)
+      throws WhitelistException {
+
+    int whitelistHostLength = InetAddresses.forString(whitelistHostIP).getAddress().length;
+    int remoteHostLength = InetAddresses.forString(remoteHost).getAddress().length;
+    if (whitelistHostLength == 4) {
+      if (remoteHostLength == 4) {
+        Ipv4Range whitelistHostRange = Ipv4Range.parse(whitelistHostCIDR);
+        return whitelistHostRange.overlaps(Ipv4Range.parse(remoteHost + "/32"));
+      }
+    } else if (whitelistHostLength == 16) {
+      if (remoteHostLength == 16) {
+        Ipv6Range whitelistHostRange = Ipv6Range.parse(whitelistHostCIDR);
+        return whitelistHostRange.overlaps(Ipv6Range.parse(remoteHost + "/128"));
+      }
+    }
+
+    return false;
+  }
+
+  static boolean verifyIpv4(final String remoteHost, final String whitelistHost)
+      throws WhitelistException {
+    Ipv4 whitelistIP = Ipv4.parse(whitelistHost);
+    return whitelistIP.equals(Ipv4.parse(remoteHost));
+  }
+
+  static boolean verifyIpv6(final String remoteHost, final String whitelistHost)
+      throws WhitelistException {
+    Ipv6 whitelistIP = Ipv6.parse(whitelistHost);
+    return whitelistIP.equals(Ipv6.parse(remoteHost));
+  }
+
+  /** Returns true if whitelistHost is equal to remoteHost; supports ipv4/ipv6. */
+  static boolean verifyIP(final String remoteHost, final String whitelistHost)
+      throws WhitelistException {
+
+    int whitelistHostLength = InetAddresses.forString(whitelistHost).getAddress().length;
+    int remoteHostLength = InetAddresses.forString(remoteHost).getAddress().length;
+    if (whitelistHostLength == 4) {
+      if (remoteHostLength == 4) {
+        return verifyIpv4(whitelistHost, remoteHost);
+      }
+    } else if (whitelistHostLength == 16) {
+      if (remoteHostLength == 16) {
+        return verifyIpv6(whitelistHost, remoteHost);
+      }
+    }
+
+    return false;
+  }
+
+  /** Returns true if whitelistHost contains remoteHost; supports ip/cidr. */
+  static Boolean whitelistContains(final String remoteHost, final String whitelistHost)
+      throws WhitelistException {
+    Boolean isMatched = false;
+
+    if (whitelistHost.equalsIgnoreCase(remoteHost)) {
+      isMatched = true;
+    }
+
+    Boolean isCIDR = false;
+    Boolean isRange = false;
+
+    String[] hostParts = whitelistHost.split("/");
+
+    String whitelistHostIP;
+    if (hostParts.length == 2) {
+      whitelistHostIP = hostParts[0];
+      isCIDR = true;
+    } else {
+      hostParts = whitelistHost.split("-");
+      if (hostParts.length == 2) {
+        isRange = true;
+      }
+    }
+
+    if (isCIDR || isRange) {
+      whitelistHostIP = hostParts[0];
+      isMatched = verifyCIDR(remoteHost, whitelistHost, whitelistHostIP);
+    } else {
+      isMatched = verifyIP(remoteHost, whitelistHost);
+    }
+
+    return isMatched;
+  }
+
   static void whitelistVerify(
       final String remoteHost,
       final WhitelistItem whitelistItem,
       final Map<String, List<String>> headers,
       final String postContent)
       throws WhitelistException {
-    if (whitelistItem.getHost().equalsIgnoreCase(remoteHost)) {
+
+    String whitelistHost = whitelistItem.getHost();
+
+    if (whitelistContains(remoteHost, whitelistHost)) {
       if (whitelistItem.isHmacEnabled()) {
         final Optional<StringCredentials> hmacKeyOpt =
             CredentialsHelper.findCredentials(whitelistItem.getHmacCredentialId());
@@ -67,5 +165,57 @@ public class WhitelistVerifier {
     }
     throw new WhitelistException(
         "Sending host \"" + remoteHost + "\" was not matched by whitelist.");
+  }
+
+  private Boolean validateIpValue(String ipValue) {
+    Boolean isValid = false;
+
+    Boolean isCIDR = false;
+    Boolean isRange = false;
+
+    String[] hostParts = ipValue.split("/");
+
+    if (hostParts.length == 2) {
+      isCIDR = true;
+    } else {
+      hostParts = ipValue.split("-");
+      if (hostParts.length == 2) {
+        isRange = true;
+      }
+    }
+
+    if (isCIDR || isRange) {
+      int leftValueLength = InetAddresses.forString(hostParts[0]).getAddress().length;
+      if (leftValueLength == 4) {
+        if (Ipv4Range.parse(ipValue) != null) {
+          isValid = true;
+        }
+      } else if (leftValueLength == 16) {
+        if (Ipv6Range.parse(ipValue) != null) {
+          isValid = true;
+        }
+      }
+    } else {
+      int ipValueLength = InetAddresses.forString(hostParts[0]).getAddress().length;
+      if (ipValueLength == 4) {
+        if (Ipv4.parse(ipValue) != null) {
+          isValid = true;
+        }
+      } else if (ipValueLength == 16) {
+        if (Ipv6.parse(ipValue) != null) {
+          isValid = true;
+        }
+      }
+    }
+
+    return isValid;
+  }
+
+  public FormValidation checkIP(@QueryParameter String value) {
+    if (validateIpValue(value)) {
+      return FormValidation.ok();
+    } else {
+      return FormValidation.error("IP Address must be in IPV4 or IPV6 CIDR or IP range notation.");
+    }
   }
 }

--- a/src/main/java/org/jenkinsci/plugins/gwt/whitelist/WhitelistVerifier.java
+++ b/src/main/java/org/jenkinsci/plugins/gwt/whitelist/WhitelistVerifier.java
@@ -49,12 +49,13 @@ public class WhitelistVerifier {
   }
 
   /**
-   * Returns true if the provided whitelistHost CIDR block contains the
-   * remoteHost; supports ipv4/ipv6.
+   * Returns true if the provided whitelistHost CIDR block contains the remoteHost; supports
+   * ipv4/ipv6.
+   *
    * @param remoteHost
    * @param whitelistHostCIDR
    * @param whitelistHostIP
-   * @return
+   * @return boolean
    * @throws WhitelistException
    */
   static boolean verifyCIDR(
@@ -79,11 +80,11 @@ public class WhitelistVerifier {
   }
 
   /**
-   * Returns true if the provided ipv4 remoteHost value is equal to the ipv4
-   * whitelistHost value.
+   * Returns true if the provided ipv4 remoteHost value is equal to the ipv4 whitelistHost value.
+   *
    * @param remoteHost
    * @param whitelistHost
-   * @return
+   * @return boolean
    * @throws WhitelistException
    */
   static boolean verifyIpv4(final String remoteHost, final String whitelistHost)
@@ -92,61 +93,58 @@ public class WhitelistVerifier {
     return whitelistIP.equals(Ipv4.parse(remoteHost));
   }
 
-  
   /**
-   * Returns true if the provided ipv6 remoteHost value is equal to the ipv6
-   * whitelistHost value.
+   * Returns true if the provided ipv6 remoteHost value is equal to the ipv6 whitelistHost value.
+   *
    * @param remoteHost
    * @param whitelistHost
-   * @return
+   * @return boolean
    * @throws WhitelistException
    */
   static boolean verifyIpv6(final String remoteHost, final String whitelistHost)
       throws WhitelistException {
-    Ipv6 whitelistIP = Ipv6.parse(whitelistHost);
-    return whitelistIP.equals(Ipv6.parse(remoteHost));
+    return Ipv6.parse(whitelistHost).equals(Ipv6.parse(remoteHost));
   }
 
   /**
    * Returns true if whitelistHost is equal to remoteHost; supports ipv4/ipv6.
+   *
    * @param remoteHost
    * @param whitelistHost
-   * @return
+   * @return boolean
    * @throws WhitelistException
    */
   static boolean verifyIP(final String remoteHost, final String whitelistHost)
       throws WhitelistException {
+    boolean isIpValid = false;
 
     int whitelistHostLength = InetAddresses.forString(whitelistHost).getAddress().length;
     int remoteHostLength = InetAddresses.forString(remoteHost).getAddress().length;
-    if (whitelistHostLength == 4) {
-      if (remoteHostLength == 4) {
-        return verifyIpv4(whitelistHost, remoteHost);
-      }
-    } else if (whitelistHostLength == 16) {
-      if (remoteHostLength == 16) {
-        return verifyIpv6(whitelistHost, remoteHost);
-      }
+    if (whitelistHostLength == 4 && remoteHostLength == 4) {
+      isIpValid = verifyIpv4(whitelistHost, remoteHost);
+    } else if (whitelistHostLength == 16 && remoteHostLength == 16) {
+      isIpValid = verifyIpv6(whitelistHost, remoteHost);
     }
 
-    return false;
+    return isIpValid;
   }
 
   /**
    * Returns true if whitelistHost contains remoteHost; supports ip/cidr.
+   *
    * @param remoteHost
    * @param whitelistHost
-   * @return
+   * @return boolean
    * @throws WhitelistException
    */
-  static Boolean whitelistContains(final String remoteHost, final String whitelistHost)
+  static boolean whitelistContains(final String remoteHost, final String whitelistHost)
       throws WhitelistException {
     if (whitelistHost.equalsIgnoreCase(remoteHost)) {
       return true;
     }
 
-    Boolean isCIDR = false;
-    Boolean isRange = false;
+    boolean isCIDR = false;
+    boolean isRange = false;
 
     String[] hostParts = whitelistHost.split("/");
 
@@ -161,7 +159,7 @@ public class WhitelistVerifier {
       }
     }
 
-    Boolean isMatched = false;
+    boolean isMatched = false;
 
     try {
       if (isCIDR || isRange) {

--- a/src/test/java/org/jenkinsci/plugins/gwt/whitelist/WhitelistVerifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gwt/whitelist/WhitelistVerifierTest.java
@@ -93,6 +93,49 @@ public class WhitelistVerifierTest {
     assertThat(testDoVerifyWhitelist("whateverhost4", headers, postContent, whitelist)).isFalse();
   }
 
+  @Test
+  public void testThatHostCanBeVerifiedWithSupportedNotations() {
+    final WhitelistItem whitelistItem1 = new WhitelistItem("1.2.3.4");
+    whitelistItem1.setHmacEnabled(false);
+
+    final WhitelistItem whitelistItem2 = new WhitelistItem("2.2.3.0/24");
+    whitelistItem2.setHmacEnabled(false);
+
+    final WhitelistItem whitelistItem3 = new WhitelistItem("3.2.1.1-3.2.1.10");
+    whitelistItem3.setHmacEnabled(false);
+
+    final WhitelistItem whitelistItem4 =
+        new WhitelistItem("2001:0db8:85a3:0000:0000:8a2e:0370:7334");
+    whitelistItem4.setHmacEnabled(false);
+
+    final WhitelistItem whitelistItem5 =
+        new WhitelistItem("2002:0db8:85a3:0000:0000:8a2e:0370:7334/127");
+    whitelistItem5.setHmacEnabled(false);
+
+    final Map<String, List<String>> headers = new HashMap<String, List<String>>();
+    final String postContent = "";
+
+    final boolean enabled = true;
+    final Whitelist whitelist =
+        new Whitelist(
+            enabled,
+            Arrays.asList(
+                whitelistItem1, whitelistItem2, whitelistItem3, whitelistItem4, whitelistItem5));
+
+    assertThat(testDoVerifyWhitelist("1.2.3.4", headers, postContent, whitelist)).isTrue();
+    assertThat(testDoVerifyWhitelist("2.2.3.50", headers, postContent, whitelist)).isTrue();
+    assertThat(testDoVerifyWhitelist("3.2.1.5", headers, postContent, whitelist)).isTrue();
+    assertThat(testDoVerifyWhitelist("1.1.1.2", headers, postContent, whitelist)).isFalse();
+    assertThat(
+            testDoVerifyWhitelist(
+                "2001:0db8:85a3:0000:0000:8a2e:0370:7334", headers, postContent, whitelist))
+        .isTrue();
+    assertThat(
+            testDoVerifyWhitelist(
+                "2002:0db8:85a3:0000:0000:8a2e:0370:7335", headers, postContent, whitelist))
+        .isTrue();
+  }
+
   private boolean testDoVerifyWhitelist(
       final String remoteHost,
       final Map<String, List<String>> headers,


### PR DESCRIPTION
Some providers rely on IP-based subnetting for their webhook APIs (e.g. GitHub.com). Also support for multiple IPs has been requested in #141.

- [x] Add support for CIDR whitelist host values.
- [ ] Add form field validation for whitelist host values.