### PR TITLE
Fix whitelist host validation

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gwt/global/WhitelistItem.java
+++ b/src/main/java/org/jenkinsci/plugins/gwt/global/WhitelistItem.java
@@ -145,10 +145,10 @@ public class WhitelistItem extends AbstractDescribableImpl<WhitelistItem> implem
         } else if (valueLength == 16) {
           isValid = Ipv6.parse(value) != null;
         }
-      }
 
-      if (isValid && !value.contains("/") && !value.contains("-")) {
-        isValid = InetAddresses.isInetAddress(value);
+        if (isValid) {
+          isValid = InetAddresses.isInetAddress(value);
+        }
       }
 
       return isValid;

--- a/src/main/java/org/jenkinsci/plugins/gwt/global/WhitelistItem.java
+++ b/src/main/java/org/jenkinsci/plugins/gwt/global/WhitelistItem.java
@@ -169,21 +169,14 @@ public class WhitelistItem extends AbstractDescribableImpl<WhitelistItem> implem
      */
     public FormValidation doCheckHost(@QueryParameter final String value) {
       try {
-        boolean isValidDomain = InternetDomainName.isValid(value);
-
-        boolean isValidIp = false;
-        if (!isValidDomain) {
-          isValidIp = validateIpValue(value);
-        }
-
-        if (isValidDomain || isValidIp) {
+        if (validateIpValue(value)) {
           return FormValidation.ok();
         }
       } catch (IllegalArgumentException e) {
-        // NOTE: Generic error message avoids assuming domain/ip value type.
+        FormValidation.error(e.getMessage());
       }
 
-      return FormValidation.error("Invalid domain, IP address, CIDR block or IP range.");
+      return FormValidation.error("Invalid IP address, CIDR block or IP range.");
     }
   }
 }

--- a/src/main/java/org/jenkinsci/plugins/gwt/global/WhitelistItem.java
+++ b/src/main/java/org/jenkinsci/plugins/gwt/global/WhitelistItem.java
@@ -138,6 +138,13 @@ public class WhitelistItem extends AbstractDescribableImpl<WhitelistItem> implem
         } else if (leftValueLength == 16) {
           isValid = Ipv6Range.parse(value) != null;
         }
+
+        if (isValid && isRange) {
+          String leftValue = hostParts[0];
+          String rightValue = hostParts[1];
+          isValid = InetAddresses.isInetAddress(leftValue);
+          isValid = InetAddresses.isInetAddress(rightValue);
+        }
       } else {
         int valueLength = InetAddresses.forString(hostParts[0]).getAddress().length;
         if (valueLength == 4) {

--- a/src/main/java/org/jenkinsci/plugins/gwt/global/WhitelistItem.java
+++ b/src/main/java/org/jenkinsci/plugins/gwt/global/WhitelistItem.java
@@ -1,5 +1,11 @@
 package org.jenkinsci.plugins.gwt.global;
 
+import com.github.jgonian.ipmath.Ipv4;
+import com.github.jgonian.ipmath.Ipv4Range;
+import com.github.jgonian.ipmath.Ipv6;
+import com.github.jgonian.ipmath.Ipv6Range;
+import com.google.common.net.InetAddresses;
+import com.google.common.net.InternetDomainName;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
@@ -100,6 +106,77 @@ public class WhitelistItem extends AbstractDescribableImpl<WhitelistItem> implem
 
     public FormValidation doCheckHmacCredentialIdItems(@QueryParameter final String value) {
       return CredentialsHelper.doCheckFillCredentialsId(value);
+    }
+
+    /**
+     * Returns true if the provided value is a valid ipv4/ipv6 string.
+     *
+     * @param value
+     * @return boolean
+     */
+    private boolean validateIpValue(final String value) {
+      boolean isValid = false;
+
+      boolean isCIDR = false;
+      boolean isRange = false;
+
+      String[] hostParts = value.split("/");
+
+      if (hostParts.length == 2) {
+        isCIDR = true;
+      } else {
+        hostParts = value.split("-");
+        if (hostParts.length == 2) {
+          isRange = true;
+        }
+      }
+
+      if (isCIDR || isRange) {
+        int leftValueLength = InetAddresses.forString(hostParts[0]).getAddress().length;
+        if (leftValueLength == 4) {
+          isValid = Ipv4Range.parse(value) != null;
+        } else if (leftValueLength == 16) {
+          isValid = Ipv6Range.parse(value) != null;
+        }
+      } else {
+        int valueLength = InetAddresses.forString(hostParts[0]).getAddress().length;
+        if (valueLength == 4) {
+          isValid = Ipv4.parse(value) != null;
+        } else if (valueLength == 16) {
+          isValid = Ipv6.parse(value) != null;
+        }
+      }
+
+      if (isValid && !value.contains("/") && !value.contains("-")) {
+        isValid = InetAddresses.isInetAddress(value);
+      }
+
+      return isValid;
+    }
+
+    /**
+     * See: https://wiki.jenkins.io/display/JENKINS/Form+Validation
+     *
+     * @param value
+     * @return FormValidation
+     */
+    public FormValidation doCheckHost(@QueryParameter final String value) {
+      try {
+        boolean isValidDomain = InternetDomainName.isValid(value);
+
+        boolean isValidIp = false;
+        if (!isValidDomain) {
+          isValidIp = validateIpValue(value);
+        }
+
+        if (isValidDomain || isValidIp) {
+          return FormValidation.ok();
+        }
+      } catch (IllegalArgumentException e) {
+        // NOTE: Generic error message avoids assuming domain/ip value type.
+      }
+
+      return FormValidation.error("Invalid domain, IP address, CIDR block or IP range.");
     }
   }
 }

--- a/src/main/resources/org/jenkinsci/plugins/gwt/global/WhitelistItem/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/gwt/global/WhitelistItem/config.jelly
@@ -2,7 +2,7 @@
 <?jelly escape-by-default='true' ?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
 
-  <f:entry field="host" title="Domain, IP, CIDR or IP range">
+  <f:entry field="host" title="IP, CIDR or IP range">
     <f:textbox />
   </f:entry>
 

--- a/src/main/resources/org/jenkinsci/plugins/gwt/global/WhitelistItem/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/gwt/global/WhitelistItem/config.jelly
@@ -2,7 +2,7 @@
 <?jelly escape-by-default='true' ?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
 
-  <f:entry field="host" title="IP, CIDR or IP range">
+  <f:entry field="host" title="Domain, IP, CIDR or IP range">
     <f:textbox />
   </f:entry>
 

--- a/src/main/resources/org/jenkinsci/plugins/gwt/global/WhitelistItem/help-host.html
+++ b/src/main/resources/org/jenkinsci/plugins/gwt/global/WhitelistItem/help-host.html
@@ -1,9 +1,12 @@
-Is the IP of a server that is allowed to invoke the plugin. This can be
+Is the domain or IP of a server that is allowed to invoke the plugin. This can be
 <b>CIDR</b> or ranges:
 <ul>
+  <li>WINS_SERVER</li>
+  <li>example.com</li>
   <li>1.2.3.4</li>
   <li>2.2.3.0/24</li>
   <li>3.2.1.1-3.2.1.10</li>
   <li>2001:0db8:85a3:0000:0000:8a2e:0370:7334</li>
   <li>2002:0db8:85a3:0000:0000:8a2e:0370:7334/127</li>
+  <li>2001:0db8:85a3:0000:0000:8a2e:0370:7334-2001:0db8:85a3:0000:0000:8a2e:0370:7335</li>
 </ul>

--- a/src/main/resources/org/jenkinsci/plugins/gwt/global/WhitelistItem/help-host.html
+++ b/src/main/resources/org/jenkinsci/plugins/gwt/global/WhitelistItem/help-host.html
@@ -1,8 +1,6 @@
-Is the domain or IP of a server that is allowed to invoke the plugin. This can be
+Is the IP of a server that is allowed to invoke the plugin. This can be
 <b>CIDR</b> or ranges:
 <ul>
-  <li>WINS_SERVER</li>
-  <li>example.com</li>
   <li>1.2.3.4</li>
   <li>2.2.3.0/24</li>
   <li>3.2.1.1-3.2.1.10</li>


### PR DESCRIPTION
Whitelist hosts aren't validated when configuring the plugin. IP addresses, CIDR blocks, and IP ranges are all supported; indicating errors should be fairly trivial.

- [x] Add form validation for the whitelist host field.

