### PR TITLE
Issue 159, Allow user to override quiet period if they so choose.

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/gwt/GenericTrigger/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/gwt/GenericTrigger/config.jelly
@@ -63,6 +63,17 @@
    </f:description>
  </f:entry>
 
+ <f:entry title="Override Quiet Period" field="overrideQuietPeriod">
+   <f:checkbox/>
+   <f:description>
+    Allow the trigger to override this job's quiet period. If selected you can you can provide a quiet period (an integer number of seconds) and the build will use that quiet period instead of its default. If this is selected and no quiet period is given the job's quiet period will still be used. It can be supplied as a:
+    <ul>
+      <li>Query Parameter <b>/invoke?jobQuietPeriod=QUIET_PERIOD_HERE</b></li>
+      <li>A quiet period header <b>jobQuietPeriod: QUIET_PERIOD_HERE</b></li>
+    </ul>
+   </f:description>
+ </f:entry>
+
  <f:entry title="Silent response" field="silentResponse">
    <f:checkbox/>
    <f:description>

--- a/src/test/java/org/jenkinsci/plugins/gwt/GenericWebHookRequestReceiverTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gwt/GenericWebHookRequestReceiverTest.java
@@ -28,6 +28,18 @@ public class GenericWebHookRequestReceiverTest {
   }
 
   @Test
+  public void testThatNoQuietPeriodGivesNegOne() {
+    final GenericWebHookRequestReceiver sut = new GenericWebHookRequestReceiver();
+    final Map<String, List<String>> headers = newHashMap();
+    final Map<String, String[]> parameterMap = newHashMap();
+
+    final int actual = sut.getGivenQuietPeriod(headers, parameterMap);
+
+    assertThat(actual) //
+        .isEqualTo(-1);
+  }
+
+  @Test
   public void testThatParameterTokenGivesThatToken() {
     final GenericWebHookRequestReceiver sut = new GenericWebHookRequestReceiver();
     final Map<String, List<String>> headers = newHashMap();
@@ -42,6 +54,20 @@ public class GenericWebHookRequestReceiverTest {
   }
 
   @Test
+  public void testThatParameterQuietPeriodGivesThatQueitPeriod() {
+    final GenericWebHookRequestReceiver sut = new GenericWebHookRequestReceiver();
+    final Map<String, List<String>> headers = newHashMap();
+    final Map<String, String[]> parameterMap =
+        of( //
+            "jobQuietPeriod", new String[] {"1"});
+
+    final int actual = sut.getGivenQuietPeriod(headers, parameterMap);
+
+    assertThat(actual) //
+        .isEqualTo(1);
+  }
+
+  @Test
   public void testThatHeaderTokenGivesThatToken() {
     final GenericWebHookRequestReceiver sut = new GenericWebHookRequestReceiver();
     final Map<String, List<String>> headers =
@@ -53,6 +79,34 @@ public class GenericWebHookRequestReceiverTest {
 
     assertThat(actual) //
         .isEqualTo("tokenHeader");
+  }
+
+  @Test
+  public void testThatHeaderQuietPeriodGivesThatQueitPeriod() {
+    final GenericWebHookRequestReceiver sut = new GenericWebHookRequestReceiver();
+    final Map<String, List<String>> headers =
+        of( //
+            "jobQuietPeriod", (List<String>) newArrayList("1"));
+    final Map<String, String[]> parameterMap = newHashMap();
+
+    final int actual = sut.getGivenQuietPeriod(headers, parameterMap);
+
+    assertThat(actual) //
+        .isEqualTo(1);
+  }
+
+  @Test
+  public void testThatNonsensicalQuietPeriodGivesNegOne() {
+    final GenericWebHookRequestReceiver sut = new GenericWebHookRequestReceiver();
+    final Map<String, List<String>> headers = newHashMap();
+    final Map<String, String[]> parameterMap =
+        of( //
+            "jobQuietPeriod", new String[] {"fooBar"});
+
+    final int actual = sut.getGivenQuietPeriod(headers, parameterMap);
+
+    assertThat(actual) //
+        .isEqualTo(-1);
   }
 
   @Test


### PR DESCRIPTION
Provides the option on a job to allow its quiet period to be overridden. If that option is selected and the user passes in a quiet period that's parsed as an int then the quiet period for this run will be whatever the user set.