### PR TITLE
Update logging path for Render

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gwt/Renderer.java
+++ b/src/main/java/org/jenkinsci/plugins/gwt/Renderer.java
@@ -15,7 +15,7 @@ import java.util.Set;
 import java.util.logging.Logger;
 
 public class Renderer {
-  private static Logger LOGGER = Logger.getLogger(Renderer.class.getSimpleName());
+  private static Logger LOGGER = Logger.getLogger(Renderer.class.getName());
 
   @VisibleForTesting
   public static boolean isMatching(


### PR DESCRIPTION
Logging for Render is not in the plugin's namespace, just shows up as
Render.  Updating the call to use getClassName instead of Simple which is just the class name and not the package with namespace.  This is what's done in PostContentParameterResolver.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [] Link to relevant issues in GitHub or Jira
- [] Link to relevant pull requests, esp. upstream and downstream changes
- [] Ensure you have provided tests - that demonstrates feature works or fixes the issue

I don't have a way of testing or building this code base, some assistance in that area would be nice, this is such a small change.
