### PR TITLE
Replace jenkins with example.org in public facing error message.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gwt/GenericWebHookRequestReceiver.java
+++ b/src/main/java/org/jenkinsci/plugins/gwt/GenericWebHookRequestReceiver.java
@@ -53,7 +53,7 @@ public class GenericWebHookRequestReceiver extends CrumbExclusion implements Unp
           + GenericTrigger.class.getSimpleName()
           + " configured! "
           + "If you are using a token, you need to pass it like ...trigger/invoke?token=TOKENHERE. "
-          + "If you are not using a token, you need to authenticate like http://user:passsword@jenkins/generic-webhook... ";
+          + "If you are not using a token, you need to authenticate like http://user:passsword@example.org/generic-webhook... ";
   private static final String URL_NAME = "generic-webhook-trigger";
   private static final Logger LOGGER =
       Logger.getLogger(GenericWebHookRequestReceiver.class.getName());


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->

Commit simply replaces the "jenkins" string in the public facing error message with "example.org". See jenkinsci/generic-webhook-trigger-plugin#235 for issue.