### PR TITLE
Interpolate variables contributed within regexpFilterExpression

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gwt/GenericTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/gwt/GenericTrigger.java
@@ -162,7 +162,9 @@ public class GenericTrigger extends Trigger<Job<?, ?>> {
             .getVariables();
 
     final String renderedRegexpFilterText = renderText(this.regexpFilterText, resolvedVariables);
-    final boolean isMatching = isMatching(renderedRegexpFilterText, this.regexpFilterExpression);
+    final String renderedRegexpFilterExpression =
+        renderText(this.regexpFilterExpression, resolvedVariables);
+    final boolean isMatching = isMatching(renderedRegexpFilterText, renderedRegexpFilterExpression);
 
     hudson.model.Queue.Item item = null;
     if (isMatching) {


### PR DESCRIPTION
Variables used within `regexpFilterExpression` are not interpolated.
This change mimic the existing `regexpFilterText` interpolation which extends the number cases covered by the plugin.