### PR TITLE
change filter to optional parameter in Job DSL

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gwt/GenericTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/gwt/GenericTrigger.java
@@ -30,8 +30,8 @@ import org.kohsuke.stapler.QueryParameter;
 public class GenericTrigger extends Trigger<Job<?, ?>> {
 
   private List<GenericVariable> genericVariables = newArrayList();
-  private final String regexpFilterText;
-  private final String regexpFilterExpression;
+  private String regexpFilterText;
+  private String regexpFilterExpression;
   private List<GenericRequestVariable> genericRequestVariables = newArrayList();
   private List<GenericHeaderVariable> genericHeaderVariables = newArrayList();
   private boolean printPostContent;
@@ -70,15 +70,21 @@ public class GenericTrigger extends Trigger<Job<?, ?>> {
   @DataBoundConstructor
   public GenericTrigger(
       final List<GenericVariable> genericVariables,
-      final String regexpFilterText,
-      final String regexpFilterExpression,
       final List<GenericRequestVariable> genericRequestVariables,
       final List<GenericHeaderVariable> genericHeaderVariables) {
     this.genericVariables = genericVariables;
-    this.regexpFilterExpression = regexpFilterExpression;
-    this.regexpFilterText = regexpFilterText;
     this.genericRequestVariables = genericRequestVariables;
     this.genericHeaderVariables = genericHeaderVariables;
+  }
+
+  @DataBoundSetter
+  public void setRegexpFilterText(final String regexpFilterText) {
+    this.regexpFilterText = regexpFilterText;
+  }
+
+  @DataBoundSetter
+  public void setRegexpFilterExpression(final String regexpFilterExpression) {
+    this.regexpFilterExpression = regexpFilterExpression;
   }
 
   @DataBoundSetter

--- a/src/test/java/org/jenkinsci/plugins/gwt/jobfinder/JobFinderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gwt/jobfinder/JobFinderTest.java
@@ -64,7 +64,7 @@ public class JobFinderTest {
         .thenReturn("name-" + this.atomicInteger.incrementAndGet());
     final Map<TriggerDescriptor, Trigger<?>> triggers = new HashMap<>();
     final TriggerDescriptor typeDescr = mock(TriggerDescriptor.class);
-    final GenericTrigger genericTrigger = new GenericTrigger(null, null, null, null, null);
+    final GenericTrigger genericTrigger = new GenericTrigger(null, null, null);
     genericTrigger.setToken(genericToken);
     triggers.put(typeDescr, genericTrigger);
     when(mock.getTriggers()) //


### PR DESCRIPTION
### Detail

 - Fix #83
 - The `Expression (regexpFilterExpression)` and `Text (regexpFilterText)` is optional field in Web UI, but there are required parameter in Job DSL (because constructor use those params.)
 - Excluding these two fields from constructor, and adding setter.
 - Tested with 1.87.0 and this new version.
   - using 1.87.0, in `Job DSL API Reference` - the field is required - ![image](https://github.com/jenkinsci/generic-webhook-trigger-plugin/assets/16630665/b6dbaccb-c637-4a8a-9441-c83f465ccef3)
   - using this commit, in `Job DSL API Reference`
     - the field is not required
     - ![image](https://github.com/jenkinsci/generic-webhook-trigger-plugin/assets/16630665/6fc19dba-a30c-4021-b165-025909b186e6)
   - using 1.87.0, without `regexpFilterText`, `regexpFilterExpression` - ![image](https://github.com/jenkinsci/generic-webhook-trigger-plugin/assets/16630665/de92ed0c-4d77-40b5-80c8-afc34304bdc1) - ![image](https://github.com/jenkinsci/generic-webhook-trigger-plugin/assets/16630665/8db1a3d1-93d2-47ca-b663-0c530cdb1c06)
   - with this commit, without `regexpFilterText`, `regexpFilterExpression`
     - ![image](https://github.com/jenkinsci/generic-webhook-trigger-plugin/assets/16630665/5b0eab26-2e0f-4168-9bc2-2be3f69431c3)
   - with this commit, with `regexpFilterText`, `regexpFilterExpression` - ![image](https://github.com/jenkinsci/generic-webhook-trigger-plugin/assets/16630665/b94d3ab7-0ebf-45eb-be68-c11a6b5876e2)

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
