### PR TITLE
Test with Java 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,6 @@
 buildPlugin(
   useContainerAgent: true,
   configurations: [
+    [platform: 'linux', jdk: 21],
     [platform: 'linux', jdk: 17],
-    [platform: 'linux', jdk: 11],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -210,15 +210,19 @@
 		</dependency>
 
 		<!-- test // -->
+                <!-- mockito must precede assertj until assertj supports Java 21 -->
+                <!-- TODO: restore ordering when assertj includes a Java 21 compatible bytebuddy library -->
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+                <!-- assertj must follow mockito until assertj supports Java 21 -->
+                <!-- TODO: restore ordering when assertj includes a Java 21 compatible bytebuddy library -->
 		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
 			<version>3.24.2</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-core</artifactId>
 			<scope>test</scope>
 		</dependency>
 


### PR DESCRIPTION
## Test with Java 21

Java 21 was released Sep 19, 2023. We want to announce full support for Java 21 in early October and would like the most used plugins to be compiled and tested with Java 21.

The acceptance test harness and plugin bill of materials tests are already passing with Java 21. This is a further step to improve plugin readiness for use with Java 21 and for development with Java 21.

The change intentionally tests only two Java configurations, Java 17 and Java 21 because we believe that the risk of a regression that only affects Java 11 is low. We generate Java 11 byte code with the Java 17 and the Java 21 builds, so we're already testing Java 11 byte code.

Place mockito before assertj to avoid Java 21 error due to assertj dependencies not supporting Java 21.

### Testing done

Confirmed that tests pass with Java 21 on Linux.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
