### PR TITLE
Replace JSR-305 annotations with spotbugs annotations

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gwt/GenericWebhookEnvironmentContributor.java
+++ b/src/main/java/org/jenkinsci/plugins/gwt/GenericWebhookEnvironmentContributor.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.gwt;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.model.EnvironmentContributor;
@@ -7,7 +8,6 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import java.io.IOException;
 import java.util.Map;
-import javax.annotation.Nonnull;
 
 @Extension
 public class GenericWebhookEnvironmentContributor extends EnvironmentContributor {
@@ -15,9 +15,9 @@ public class GenericWebhookEnvironmentContributor extends EnvironmentContributor
   @SuppressWarnings("unchecked")
   @Override
   public void buildEnvironmentFor(
-      @SuppressWarnings("rawtypes") @Nonnull final Run r,
-      @Nonnull final EnvVars envs,
-      @Nonnull final TaskListener listener)
+      @SuppressWarnings("rawtypes") @NonNull final Run r,
+      @NonNull final EnvVars envs,
+      @NonNull final TaskListener listener)
       throws IOException, InterruptedException {
     final GenericCause cause = (GenericCause) r.getCause(GenericCause.class);
     if (cause != null) {


### PR DESCRIPTION
## Replace JSR-305 annotations with spotbugs annotations

Annotations for Nonnull, CheckForNull, and several others were proposed for Java as part of dormant Java specification request JSR-305. The proposal never became a part of standard Java.

Jenkins plugins should switch from using JSR-305 annotations to use Spotbugs annotations that provide the same semantics.

The [mailing list discussion](https://groups.google.com/g/jenkinsci-dev/c/uE1wwtVi1W0/m/gLxdEJmlBQAJ) from James Nord describes the affected annotations and why they should be replaced with annotations that are actively maintained.

The ["Improve a plugin" tutorial](https://www.jenkins.io/doc/developer/tutorial-improve/replace-jsr-305-annotations/) provides instructions to perform this change.

An [OpenRewrite recipe](https://docs.openrewrite.org/recipes/jenkins/javaxannotationstospotbugs) is also available and is even better than the tutorial.

### Testing done

Confirmed that automated tests pass on Linux with Java 21.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
