### PR TITLE
Adding a FINE level log message when effectively triggering

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gwt/Renderer.java
+++ b/src/main/java/org/jenkinsci/plugins/gwt/Renderer.java
@@ -35,6 +35,14 @@ public class Renderer {
                             + "\" not matching \""
                             + renderedRegexpFilterText
                             + "\".");
+        }else{
+			LOGGER.log(
+					FINE,
+					"Triggering \""
+							+ regexpFilterExpression
+							+ "\" matching \""
+							+ renderedRegexpFilterText
+							+ "\".");
         }
         return isMatching;
     }


### PR DESCRIPTION
Using Jenkins' LogRecorder, we can access log messages that are set more verbose than INFO (i.e., CONFIG, FINE, FINER, FINEST). When doing so, to see which job got triggered we currently have to proceed by elimination. Adding this log message can help determining which job got triggered by a specific webhook call.

https://github.com/jenkinsci/generic-webhook-trigger-plugin/issues/93 

https://github.com/jenkinsci/generic-webhook-trigger-plugin/pull/227

### Testing done

this single liner does not require test.

### Submitter checklist
- [x ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x ] Ensure that the pull request title represents the desired changelog entry
- [x ] Please describe what you did
- [x ] Link to relevant issues in GitHub or Jira
- [x ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue


