### PR TITLE
Update SCM URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,8 @@
   </developers>
 
   <scm>
-    <connection>scm:git:https://github.com:jenkinsci/generic-webhook-trigger-plugin.git</connection>
-    <developerConnection>scm:git:https@github.com:jenkinsci/generic-webhook-trigger-plugin.git</developerConnection>
+    <connection>scm:git:https://github.com/jenkinsci/generic-webhook-trigger-plugin</connection>
+    <developerConnection>scm:git:https://github.com/jenkinsci/generic-webhook-trigger-plugin</developerConnection>
     <tag>generic-webhook-trigger-1.86.1</tag>
     <url>https://github.com/jenkinsci/generic-webhook-trigger-plugin</url>
   </scm>

--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,8 @@
   </developers>
 
   <scm>
-    <connection>scm:git:ssh://github.com:jenkinsci/generic-webhook-trigger-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/generic-webhook-trigger-plugin.git</developerConnection>
+    <connection>scm:git:https://github.com:jenkinsci/generic-webhook-trigger-plugin.git</connection>
+    <developerConnection>scm:git:https@github.com:jenkinsci/generic-webhook-trigger-plugin.git</developerConnection>
     <tag>generic-webhook-trigger-1.86.1</tag>
     <url>https://github.com/jenkinsci/generic-webhook-trigger-plugin</url>
   </scm>


### PR DESCRIPTION
As noted in https://www.jenkins.io/doc/developer/tutorial-improve/update-scm-url/:

"GitHub has deprecated one of the unauthenticated access protocols (git:// protocol). The pom.xml section that defines the scm for the plugin should refer to the repository with the https:// protocol instead of the git:// protocol."

### Testing done

Ran `mvn clean verify` successfully.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue