### PR TITLE
Prepare for Java 25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.13</version>
+    <version>5.19</version>
   </parent>
 
   <artifactId>generic-webhook-trigger</artifactId>
@@ -57,7 +57,7 @@
   <properties>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.baseline>2.479</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <violations.version>2.2.0</violations.version>
     <changelog>2.2.4</changelog>
     <spotless.check.skip>false</spotless.check.skip>
@@ -130,16 +130,24 @@
       <version>7.20.1</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <!-- TODO: Remove when mockito upgrades to support Java 25 -->
+      <groupId>net.bytebuddy</groupId>
+      <artifactId>byte-buddy</artifactId>
+      <version>1.17.6</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <version>3.27.3</version>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <version>5.18.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>4669.v0e99c712a_30e</version>
+        <version>5054.v620b_5d2b_d5e6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>4051.v78dce3ce8b_d6</version>
+        <version>4669.v0e99c712a_30e</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/org/jenkinsci/plugins/gwt/global/CredentialsHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/gwt/global/CredentialsHelper.java
@@ -10,7 +10,6 @@ import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import com.google.common.base.Optional;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.Item;
 import hudson.model.Queue;
 import hudson.model.queue.Tasks;
@@ -25,7 +24,6 @@ import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 
 public class CredentialsHelper {
 
-    @SuppressFBWarnings("NP_NULL_PARAM_DEREF")
     public static ListBoxModel doFillCredentialsIdItems(final Item item, final String credentialsId) {
         final StandardListBoxModel result = new StandardListBoxModel();
         if (item == null) {


### PR DESCRIPTION
## Prepare for Java 25

Java 25 is scheduled to release September 16, 2025.  The Jenkins project would like to support Java 25 soon after its release.

The changes in this pull request allow the plugin to successfully compile and test with Java 25 early access 35.

Replaces pull requests:

* #362
* #360

### Testing done

Confirmed that `mvn clean verify` passes with Java 25 and Java 21.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
