### PR TITLE
Add UUID parameter to safe parameter names

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gwt/ParameterActionUtil.java
+++ b/src/main/java/org/jenkinsci/plugins/gwt/ParameterActionUtil.java
@@ -12,9 +12,12 @@ import hudson.model.ParametersDefinitionProperty;
 import hudson.model.StringParameterValue;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 public class ParameterActionUtil {
+
+    private static final String UUID_PARAMETER_NAME = "jenkins-generic-webhook-trigger-plugin_uuid";
 
     public static ParametersAction createParameterAction(
             final ParametersDefinitionProperty parametersDefinitionProperty,
@@ -25,11 +28,9 @@ public class ParameterActionUtil {
         final boolean triggerOneBuildPerInvocation = !allowSeveralTriggersPerBuild;
         if (triggerOneBuildPerInvocation) {
             parameterList.add(new StringParameterValue(
-                    "jenkins-generic-webhook-trigger-plugin_uuid",
-                    UUID.randomUUID().toString(),
-                    null));
+                    UUID_PARAMETER_NAME, UUID.randomUUID().toString(), null));
         }
-        return new ParametersAction(parameterList);
+        return new ParametersAction(parameterList, Set.of(UUID_PARAMETER_NAME));
     }
 
     /** To keep any default values set there. */

--- a/src/test/java/org/jenkinsci/plugins/gwt/ParameterActionUtilTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gwt/ParameterActionUtilTest.java
@@ -2,14 +2,19 @@ package org.jenkinsci.plugins.gwt;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.jenkinsci.plugins.gwt.ParameterActionUtil.createParameterAction;
+import static org.mockito.Mockito.mock;
 
 import com.google.common.collect.ImmutableMap;
 import hudson.model.BooleanParameterDefinition;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
 import hudson.model.ParametersAction;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.StringParameterDefinition;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 class ParameterActionUtilTest {
@@ -112,5 +117,22 @@ class ParameterActionUtilTest {
                 .hasSize(1);
         assertThat(actualWithFalse.getAllParameters().get(0).getValue()) //
                 .isNotNull();
+    }
+
+    @Test
+    void testThatParameterIsAccessible() throws IOException {
+        final ParametersDefinitionProperty parametersDefinitionProperty = new ParametersDefinitionProperty();
+        final ParametersAction actualWithFalse = createParameterAction(parametersDefinitionProperty, Map.of(), false);
+        FreeStyleBuild mockBuild = new FreeStyleBuild(mock(FreeStyleProject.class));
+        actualWithFalse.onAttached(mockBuild);
+        assertThat(actualWithFalse.getParameters()) //
+                .hasSize(1);
+        assertThat(actualWithFalse.getParameters().get(0).getValue()) //
+                .isNotNull();
+    }
+
+    @AfterEach
+    void tearDown() {
+        System.clearProperty(ParametersAction.KEEP_UNDEFINED_PARAMETERS_SYSTEM_PROPERTY_NAME);
     }
 }


### PR DESCRIPTION
With the security hardening for SECURITY-170 as described here https://www.jenkins.io/blog/2016/05/11/security-update/, adding parameters not defined by a job raises a warning. The UUID parameter has a name unique enough that it can't be exploited, by marking it as explicitly safe we can reduce the amount of warnings in Jenkins log related to this parameter.

### Testing done

Unit tests passing

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
