### PR TITLE
Default genericVariable to empty string when missing from payload

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gwt/resolvers/PostContentParameterResolver.java
+++ b/src/main/java/org/jenkinsci/plugins/gwt/resolvers/PostContentParameterResolver.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.gwt.resolvers;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.base.Strings.nullToEmpty;
 import static com.google.common.collect.Maps.newHashMap;
 import static java.util.logging.Level.INFO;
 import static org.jenkinsci.plugins.gwt.ExpressionType.JSONPath;
@@ -44,8 +45,8 @@ public class PostContentParameterResolver {
                 final boolean notResolved = resolvedMap.isEmpty()
                         || resolvedMap.containsKey(gv.getVariableName())
                                 && resolvedMap.get(gv.getVariableName()).isEmpty();
-                if (notResolved && gv.getDefaultValue() != null) {
-                    resolvedMap.put(gv.getVariableName(), gv.getDefaultValue());
+                if (notResolved) {
+                    resolvedMap.put(gv.getVariableName(), nullToEmpty(gv.getDefaultValue()));
                 }
                 resolvedVariables.putAll(resolvedMap);
             }

--- a/src/test/java/org/jenkinsci/plugins/gwt/VariablesResolverJsonPathTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gwt/VariablesResolverJsonPathTest.java
@@ -349,6 +349,29 @@ class VariablesResolverJsonPathTest {
     }
 
     @Test
+    void testJSONPathGetPayloadVariableDefaultsToEmptyStringWhenMissingFromPayload() {
+        final String resourceName = "gitlab-mergerequest-comment.json";
+        final String postContent = this.getContent(resourceName);
+
+        final List<GenericVariable> genericVariables = newArrayList( //
+                new GenericVariable("payload", "$.doesnotexist"));
+        final Map<String, String[]> parameterMap = new HashMap<>();
+        final List<GenericRequestVariable> genericRequestVariables = new ArrayList<>();
+        final Map<String, String> variables = new VariablesResolver(
+                        this.headers,
+                        parameterMap,
+                        postContent,
+                        genericVariables,
+                        genericRequestVariables,
+                        this.genericHeaderVariables,
+                        this.shouldNotFlatten)
+                .getVariables();
+
+        assertThat(variables) //
+                .containsEntry("payload", "");
+    }
+
+    @Test
     void testStarOperator() {
         final String resourceName = "github-push-event.json";
         final Map<String, String> variables = this.getJsonPathVariables(resourceName, "$.commits[*].modified[*]");


### PR DESCRIPTION
Fixes #380

If a genericVariable uses a JSONPath that is not present in the payload, and no defaultValue is set, the variable is left out of the resolved variables. regexpFilterText then keeps the literal `$VARIABLE`, so a filter like `^$` never matches and the job does not trigger.

Two things suggest it should be an empty string instead. The README says defaultValue is optional and defaults to an empty string. And the XPath code already behaves that way, since XmlFlattener puts an empty string when the node list is empty. Only JSONPath was different.

PostContentParameterResolver already detects the unresolved case, it just skipped it when defaultValue was null. This removes that null check and uses nullToEmpty instead.

Job parameters are not affected. ParameterActionUtil.getStringValue treats an empty value the same as a missing one, so a job's own parameter default still applies.

I added a test for an expression that is not in the payload. The full test suite passes, 111 tests now instead of 110.
